### PR TITLE
Bump actions/cache from v1 to v2

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Cache Gradle Caches
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches/
           key: cache-gradle-cache
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/wrapper/
           key: cache-gradle-wrapper


### PR DESCRIPTION
We just released v2. That includes a lot of improvements.
https://github.com/actions/cache/releases/tag/v2.0.0